### PR TITLE
Add UCRT support to internal tests

### DIFF
--- a/tests/gtest_like_c.h
+++ b/tests/gtest_like_c.h
@@ -29,7 +29,7 @@ enum {TEST_PASSED, TEST_FAILED, TEST_SKIPPED};
 
 #define ASSERT_STREQ(VALUE1, VALUE2) \
     if (strcmp((VALUE1), (VALUE2))) { \
-        printf("%s:%d ASSERT_EQ(%s, %s) failed\n", __FILE__, __LINE__, #VALUE1, #VALUE2); \
+        printf("%s:%d ASSERT_EQ(%s: '%s', %s: '%s') failed\n", __FILE__, __LINE__, #VALUE1, VALUE1, #VALUE2, VALUE2); \
         longjmp(gtest_jmp, TEST_FAILED); \
     }
 

--- a/tests/math-test.c
+++ b/tests/math-test.c
@@ -67,8 +67,13 @@ void printf_test()
     assert_snprintf("float %E => 1.234560E+00", "float %%E => %E", f);
     assert_snprintf("float %g => 1.23456", "float %%g => %g", f);
     assert_snprintf("float %G => 1.23456", "float %%G => %G", f);
+#if defined _UCRT
+    assert_snprintf("float %a => 0x1.3c0c200000000p+0", "float %%a => %a", f);
+    assert_snprintf("float %A => 0X1.3C0C200000000P+0", "float %%A => %A", f);
+#else // MSVCRT
     assert_snprintf("float %a => 0x1.3c0c2p+0", "float %%a => %a", f);
     assert_snprintf("float %A => 0X1.3C0C2P+0", "float %%A => %A", f);
+#endif
 
     assert_snprintf("double %f => 1.234560", "double %%f => %f", d);
     assert_snprintf("double %F => 1.234560", "double %%F => %F", d);


### PR DESCRIPTION
The patch adds UCRT to the internal tests, as the output might differ from msvcrt. The change extends ASSERT_STREQ with more debugging information.