### PR TITLE
Verify unwinding for nonconsecutive registers

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,6 +46,7 @@ else()
     seh-fregp.cpp
     seh-large-func.cpp
     seh-stack-probing.cpp
+    seh-stp-nonconsecutive.cpp
     unwind-stack-test.c
   )
 endif()

--- a/tests/main.c
+++ b/tests/main.c
@@ -15,6 +15,7 @@ TEST(Aarch64MinGW, OmpTest);
 TEST(Aarch64MinGW, PrintfDoubleTest);
 TEST(Aarch64MinGW, SEHFregpTest);
 TEST(Aarch64MinGW, SEHLargeFunctionTest);
+TEST(Aarch64MinGW, SEHSTPNonconsecutive);
 TEST(Aarch64MinGW, SEHStackProbing);
 TEST(Aarch64MinGW, SJLJTest);
 TEST(Aarch64MinGW, SscanfDoubleTest);
@@ -73,6 +74,7 @@ int main(int argc, char **argv) {
         DECLARE_TEST(Aarch64MinGW, ExceptionChainTest),
         DECLARE_TEST(Aarch64MinGW, SEHFregpTest),
         DECLARE_TEST(Aarch64MinGW, SEHLargeFunctionTest),
+        DECLARE_TEST(Aarch64MinGW, SEHSTPNonconsecutive),
         DECLARE_TEST(Aarch64MinGW, SEHStackProbing),
         DECLARE_TEST(Aarch64MinGW, UnwindStackTest),
 #endif

--- a/tests/seh-stp-nonconsecutive.cpp
+++ b/tests/seh-stp-nonconsecutive.cpp
@@ -1,0 +1,77 @@
+#include "gtest_like_c.h"
+
+#pragma GCC push_options
+#pragma GCC optimize ("O0")
+
+static void fn4()
+{
+  register double value asm("d12") = 105;
+  ASSERT_EQ(value, 105);
+  throw (unsigned) 0x1CE;
+}
+
+static void fn3()
+{
+  register double value asm("d9") = 103;
+  register double value2 asm("d12") = 104;
+  ASSERT_EQ(value, 103);
+  ASSERT_EQ(value2, 104);
+
+  try
+  {
+    fn4();
+  }
+  catch(unsigned e)
+  {
+    ASSERT_EQ(value, 103);
+    ASSERT_EQ(value2, 104);
+  }
+}
+
+static void fn2()
+{
+  register int value asm("x25") = 0xC0DE3;
+  ASSERT_EQ(value, 0xC0DE3);
+  throw (unsigned) 0x1CE;
+}
+
+static void fn1()
+{
+  register int value asm("x25") = 0xC0DE2;
+  ASSERT_EQ(value, 0xC0DE2);
+
+  try
+  {
+    fn2();
+  }
+  catch(unsigned e)
+  {
+    ASSERT_EQ(value, 0xC0DE2);
+  }
+}
+
+void test_seh_stp_not_consecutive(void)
+{
+  register int value asm("x20") = 0xC0DE1;
+  ASSERT_EQ(value, 0xC0DE1);
+  fn1();
+  ASSERT_EQ(value, 0xC0DE1);
+
+  register double value2 asm("d9") = 101;
+  register double value3 asm("d12") = 102;
+  ASSERT_EQ(value2, 101);
+  ASSERT_EQ(value3, 102);
+  fn3();
+  ASSERT_EQ(value2, 101);
+  ASSERT_EQ(value3, 102);
+}
+
+#pragma GCC pop_options
+
+extern "C" {
+
+    TEST(Aarch64MinGW, SEHSTPNonconsecutive)
+    {
+        test_seh_stp_not_consecutive();
+    }
+}


### PR DESCRIPTION
The patch verifies
[[Binutils] Fix SEH unwind code mapping ](https://github.com/eukarpov/binutils-windows-arm64/pull/2)
[[GCC] Fix unwinding for nonconsecutive registers ](https://github.com/eukarpov/gcc-windows-arm64/pull/2)

[[Issue] Unwinding issue when variable is assigned to register](https://github.com/eukarpov/gnu-toolchain-windows-arm64/issues/28)