### PR TITLE
Add unwinding UNSPEC_STP test

### DIFF
--- a/.github/workflows/prerelease-test.yml
+++ b/.github/workflows/prerelease-test.yml
@@ -74,7 +74,7 @@ on:
 
 env:
   BINUTILS_BRANCH: ${{ inputs.bintuils_branch }}
-  GCC_BRANCH: ${{ inputs.gcc_branch }}
+  GCC_BRANCH: ${{ inputs.gcc_branch || 'seh-add-unwinding-unspec-stp' }}
   MINGW_BRANCH: ${{ inputs.mingw_branch }}
   CYGWIN_BRANCH: ${{ inputs.cygwin_branch }}
 

--- a/.github/workflows/prerelease-test.yml
+++ b/.github/workflows/prerelease-test.yml
@@ -74,7 +74,7 @@ on:
 
 env:
   BINUTILS_BRANCH: ${{ inputs.bintuils_branch }}
-  GCC_BRANCH: ${{ inputs.gcc_branch || 'seh-add-unwinding-unspec-stp' }}
+  GCC_BRANCH: ${{ inputs.gcc_branch }}
   MINGW_BRANCH: ${{ inputs.mingw_branch }}
   CYGWIN_BRANCH: ${{ inputs.cygwin_branch }}
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,6 +47,7 @@ else()
     seh-large-func.cpp
     seh-stack-probing.cpp
     seh-stp-nonconsecutive.cpp
+    seh-stp-unspec.cpp
     unwind-stack-test.c
   )
 endif()

--- a/tests/main.c
+++ b/tests/main.c
@@ -16,6 +16,7 @@ TEST(Aarch64MinGW, PrintfDoubleTest);
 TEST(Aarch64MinGW, SEHFregpTest);
 TEST(Aarch64MinGW, SEHLargeFunctionTest);
 TEST(Aarch64MinGW, SEHSTPNonconsecutive);
+TEST(Aarch64MinGW, SEHSTPUnspec);
 TEST(Aarch64MinGW, SEHStackProbing);
 TEST(Aarch64MinGW, SJLJTest);
 TEST(Aarch64MinGW, SscanfDoubleTest);
@@ -75,6 +76,7 @@ int main(int argc, char **argv) {
         DECLARE_TEST(Aarch64MinGW, SEHFregpTest),
         DECLARE_TEST(Aarch64MinGW, SEHLargeFunctionTest),
         DECLARE_TEST(Aarch64MinGW, SEHSTPNonconsecutive),
+        DECLARE_TEST(Aarch64MinGW, SEHSTPUnspec),
         DECLARE_TEST(Aarch64MinGW, SEHStackProbing),
         DECLARE_TEST(Aarch64MinGW, UnwindStackTest),
 #endif

--- a/tests/seh-stp-unspec.cpp
+++ b/tests/seh-stp-unspec.cpp
@@ -1,0 +1,55 @@
+#include "gtest_like_c.h"
+
+__attribute__((optimize("O2")))
+static int fn6(int* v1, int* v2, int* v3, int* v4, int* v5, int* v6)
+{
+    register int v13 asm("x20") = *v1;
+    register int v14 asm("x27") = *v2;
+    if (v13 != v14)
+      return 1;
+
+    register int v15 asm("x23") = *v3;
+    register int v16 asm("x24") = *v4;
+    v15 += 1;
+    v16 += 2;
+    if (v15 == v16)
+      throw (unsigned) 1;
+
+    register int v17 asm("x21") = *v5;
+    register int v18 asm("x22") = *v6;
+    v15 += 1;
+    v16 += 2;
+    if (v15 != v16)
+      throw (unsigned) 1;
+
+    return 0;
+}
+
+static int fn5()
+{
+  try
+  {
+    int value4 = 0xC0DE3;
+    fn6(&value4, &value4, &value4, &value4, &value4, &value4);
+  }
+  catch(unsigned) {
+  }
+
+  return 0;
+}
+
+static void test_seh_stp_unspec(void)
+{
+  register int value asm("x24") = 0xC0DE2;
+  ASSERT_EQ(value, 0xC0DE2);
+  fn5();
+  ASSERT_EQ(value, 0xC0DE2);
+}
+
+extern "C" {
+
+    TEST(Aarch64MinGW, SEHSTPUnspec)
+    {
+        test_seh_stp_unspec();
+    }
+}


### PR DESCRIPTION
The patch verifies
[Add SEH unwinding support for UNSPEC_STP](https://github.com/eukarpov/gcc-windows-arm64/pull/4)

Issue:
[Unwinding for STP does not support UNSPEC_STP pattern](https://github.com/eukarpov/gnu-toolchain-windows-arm64/issues/30)